### PR TITLE
Replaced dungeon level variable xchar with int.

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -522,7 +522,7 @@ E void losedogs(void);
 E void mon_arrive(struct monst *,BOOLEAN_P);
 E void mon_catchup_elapsed_time(struct monst *,long);
 E void keepdogs(BOOLEAN_P);
-E void migrate_to_level(struct monst *,XCHAR_P,XCHAR_P,coord *);
+E void migrate_to_level(struct monst *,int,XCHAR_P,coord *);
 E int dogfood(struct monst *,struct obj *);
 E struct monst *tamedog(struct monst *,struct obj *, BOOLEAN_P);
 E int make_pet_minion(int,ALIGNTYP_P);

--- a/src/dog.c
+++ b/src/dog.c
@@ -978,7 +978,7 @@ boolean pets_only;	/* true for ascension or final escape */
 void
 migrate_to_level(mtmp, tolev, xyloc, cc)
 	register struct monst *mtmp;
-	xchar tolev;	/* destination level */
+	int tolev;	/* destination level */
 	xchar xyloc;	/* MIGR_xxx destination xy location: */
 	coord *cc;	/* optional destination coordinates */
 {
@@ -1014,8 +1014,8 @@ migrate_to_level(mtmp, tolev, xyloc, cc)
 	migrating_mons = mtmp;
 	newsym(mtmp->mx,mtmp->my);
 
-	new_lev.dnum = ledger_to_dnum((xchar)tolev);
-	new_lev.dlevel = ledger_to_dlev((xchar)tolev);
+	new_lev.dnum = ledger_to_dnum(tolev);
+	new_lev.dlevel = ledger_to_dlev(tolev);
 	/* overload mtmp->[mx,my], mtmp->[mux,muy], and mtmp->mtrack[] as */
 	/* destination codes (setup flag bits before altering mx or my) */
 	xyflags = (depth(&new_lev) < depth(&u.uz));	/* 1 => up */


### PR DESCRIPTION
Was somehow missed in the original dungeon expansion patch,
theoretically could lead to crashes with pets, or the wizard.